### PR TITLE
Added animation to target with # in link

### DIFF
--- a/public_html/css/clustermap.css
+++ b/public_html/css/clustermap.css
@@ -111,5 +111,26 @@ body {
 }
 
 .popover-trigger {
-    outline: none;
+    outline: none !important;
+    box-shadow: none !important;
+}
+
+@keyframes blink {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.5); }
+    100% {transform: scale(1); }
+}
+
+@keyframes colblink {
+    0% { transform: scale(1); fill: var(--accent-color); }
+    50% { transform: scale(1.2); fill: #ff0000; }
+    100% { transform: scale(1); fill: var(--accent-color); }
+}
+
+.popover-trigger:target {
+    animation: blink 0.6s 12;
+}
+
+.popover-trigger:target .empty-host {
+    animation: colblink 0.6s 12;
 }


### PR DESCRIPTION
I added an animation to targets referenced with a # in a link, to make the seat/position easily findable. Currently, [adding `#f1r6s11` to a link](https://codamhero.dev/v2/clusters.php#f1r6s11) would scroll to that position on the cluster map, but it would still be unclear which seat it is. By merging this pull request, the position will then blink 12 times, to make that position as clear as possible.

Empty seats would also blink red to make them even more easily findable. Taken seats would just grow big and small, no color change there.

The reason for opening this pull request, is that for my [Dark Mode for Intranet extension](https://github.com/FreekBes/dark_intra), I now link to this cluster map when a person is available and logged in to a computer at Codam, passing the logged in position as a hash like described above.

By the way: I don't know elm, so I hope I added this animation in the right file and that this CSS file was not generated by elm itself. If not, please point me in the right direction and I'll add the change myself! :)